### PR TITLE
Auth tweaks for cookies

### DIFF
--- a/api/infrastructure/ServiceCollectionExtensions.cs
+++ b/api/infrastructure/ServiceCollectionExtensions.cs
@@ -174,9 +174,9 @@ namespace SS.Api.infrastructure
                     },
                     OnTokenValidated = context =>
                     {
-                        var identity = context.Principal.Identity as ClaimsIdentity;
-                        var usedClaimTypes = ClaimsTransformer.UsedProviderClaimTypes;
-                        foreach (var claim in identity.Claims.WhereToList(c=> !usedClaimTypes.Contains(c.Type)))
+                        if (!(context.Principal.Identity is ClaimsIdentity identity)) return Task.CompletedTask;
+                        foreach (var claim in identity.Claims.WhereToList(c =>
+                            !ClaimsTransformer.UsedProviderClaimTypes.Contains(c.Type)))
                             identity.RemoveClaim(claim);
                         return Task.CompletedTask;
                     },

--- a/api/infrastructure/authorization/ClaimsTransformer.cs
+++ b/api/infrastructure/authorization/ClaimsTransformer.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using SS.Api.helpers;
+using SS.Common.authorization;
 
 namespace SS.Api.infrastructure.authorization
 {
@@ -24,6 +25,9 @@ namespace SS.Api.infrastructure.authorization
             ClaimCachePeriod = TimeSpan.Parse(configuration.GetNonEmptyValue("ClaimsCachePeriod"));
         }
 
+        /// <summary>
+        /// Note these claims don't get saved in the cookie. 
+        /// </summary>
         public async Task<ClaimsPrincipal> TransformAsync(ClaimsPrincipal principal)
         {
             if (!principal.Identity.IsAuthenticated || _isTransformed) return await Task.FromResult(principal);
@@ -40,5 +44,11 @@ namespace SS.Api.infrastructure.authorization
             _isTransformed = true;
             return await Task.FromResult(principal);
         }
+
+        /// <summary>
+        /// This is so we can filter out the keycloak claims, as they're saved in the cookies and can be quite long. 
+        /// </summary>
+        public static List<string> UsedProviderClaimTypes => 
+            new List<string> { ClaimTypes.NameIdentifier, CustomClaimTypes.IdirUserName, CustomClaimTypes.FullName, CustomClaimTypes.IdirId };
     }
 }


### PR DESCRIPTION
Half the cookie size, by excluding id_token (already converted into claims), also remove unused provider claims that included their realm url. 