### PR TITLE
SS-647: Resolving issues caused by tooltips in the duty-roster page and various changes based on feedback

### DIFF
--- a/web/src/components/DutyRoster/components/DutyCard.vue
+++ b/web/src/components/DutyRoster/components/DutyCard.vue
@@ -7,7 +7,7 @@
             :key="block.id"
             :id="block.id"
             :style="{gridColumnStart: block.startTime, gridColumnEnd:block.endTime, gridRow:block.height,  backgroundColor: block.color, fontSize:'9px', textAlign: 'center', margin:0, padding:0  }"
-            v-b-tooltip.hover="block.title? block.title:''" 
+            v-b-tooltip.hover.noninteractive="block.title? block.title:''" 
             @dragover.prevent
             @drop.prevent="drop" >
                 <div 
@@ -23,7 +23,7 @@
     
         <b 
             v-if="selectedComment.comment"
-            v-b-tooltip.hover.right.v-info="selectedComment.comment"  
+            v-b-tooltip.hover.right.noninteractive.v-info="selectedComment.comment"  
             :style="{backgroundColor: '#AB0000', gridColumnStart: selectedComment.startTime, gridColumnEnd: selectedComment.endTime, gridRow:'1/3'}"> 
                 <b-icon-chat-square-text-fill font-scale="0.8" variant="white" style="transform: translate(7px,-5px);"/>
         </b>
@@ -106,7 +106,7 @@
                             <template v-slot:cell(title)="data" >
                                 <div
                                     :style="(data.value=='Not Available'||data.value=='Not Required')?'color:'+data.item.color:''"
-                                    v-b-tooltip.hover.right                                
+                                    v-b-tooltip.hover.right.noninteractive                                
                                     :title="data.item.title>20? data.item.title:''">
                                     {{data.item.title | truncate(20)}}</div>
                             </template>
@@ -365,7 +365,7 @@
 
         mounted()
         {
-            console.log(this.dutyRosterInfo)
+            //console.log(this.dutyRosterInfo)
             this.hasPermissionToEditDuty = this.userDetails.permissions.includes("EditDuties");
             this.hasPermissionToExpireDuty = this.userDetails.permissions.includes("ExpireDuties");    
             this.hasPermissionToAddAssignDuty = this.userDetails.permissions.includes("CreateAndAssignDuties");

--- a/web/src/components/DutyRoster/components/DutyRosterAssignment.vue
+++ b/web/src/components/DutyRoster/components/DutyRosterAssignment.vue
@@ -438,6 +438,9 @@
 		allDaysSelected = false;
 		weekDaysSelected = false;
 
+		initialStartDate = false;
+		initialEndDate = false;
+
 		weekDayNames = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
 
 		dayOptions = [
@@ -527,23 +530,40 @@
 			if(this.isDeleted)return;			
 			this.isSubTypeDataReady = false;
 			this.enableAllDayOptions();
-			this.initialLoad = true; 
+			this.initialLoad = true;
+			this.initialStartDate = true;
+			this.initialEndDate = true; 
 			this.loadAssignmentDetails();					           
 		}
 
 		public startDatePicked(){
-			this.toggleAllDays(false);
-			this.toggleWeekDays(false);
+			if(this.initialStartDate){
+				//console.log('startDate')
+				this.initialStartDate=false
+			}else if(!this.initialEndDate){
+				this.toggleAllDays(false);
+				this.toggleWeekDays(false);
+				this.selectedDays = [] ;
 			this.selectedDays = [] ;            
-            if (this.selectedEndDate.length) {
+				this.selectedDays = [] ;
+			}           
+			if (this.selectedEndDate.length) {
 				this.disableOutOfRangeDays();
 			}
+			
 		}
 
 		public endDatePicked(){
-			this.toggleAllDays(false);
-			this.toggleWeekDays(false);
+			if(this.initialEndDate){
+				//console.log('endDate')
+				this.initialEndDate=false
+			}else if (!this.initialStartDate) {
+				this.toggleAllDays(false);
+				this.toggleWeekDays(false);
+				this.selectedDays = [] ;
 			this.selectedDays = [] ;            
+				this.selectedDays = [] ;
+			}                 
             if (this.selectedStartDate.length) {
 				this.disableOutOfRangeDays();
 			}

--- a/web/src/components/DutyRoster/components/DutyRosterTeamMemberCard.vue
+++ b/web/src/components/DutyRoster/components/DutyRosterTeamMemberCard.vue
@@ -12,13 +12,13 @@
                     <div style="font-size:9px; line-height: 14px;">{{sheriffInfo.rank}}</div>
                     <div 
                         style="font-size:12px; line-height: 16px; font-weight: bold; text-transform: Capitalize;" 
-                        v-b-tooltip.hover                                
+                        v-b-tooltip.hover.noninteractive                               
                         :title="fullName.length>13?fullName:''">
                             {{fullName|truncate(11)}}
                     </div>
 
                     <b-row v-if="!weekView">
-                        <b-badge v-b-tooltip.hover.v-warning.html="allShifts" class="mx-auto mt-1">{{shifts[0]}}<span v-if="shifts.length>1"> ...</span></b-badge>
+                        <b-badge v-b-tooltip.hover.noninteractive.v-warning.html="allShifts" class="mx-auto mt-1">{{shifts[0]}}<span v-if="shifts.length>1"> ...</span></b-badge>
                     </b-row>
 
                     <b-row v-else style="margin:0; padding:0; font-size:10px;">
@@ -32,7 +32,7 @@
                                 {{sch.text}}                            
                         
 
-                            <b-tooltip v-if="sch.shifts.length>0" :target="'sch'+sheriffId+'-'+sch.weekday" variant="warning" show.sync ="true" triggers="hover" placement="topright">
+                            <b-tooltip v-if="sch.shifts.length>0" noninteractive :target="'sch'+sheriffId+'-'+sch.weekday" variant="warning" show.sync ="true" triggers="hover" placement="topright">
                                 <h2 class="text-danger  mb-1 mx-0 p-0">{{sch.name}}</h2>
                                 <b-card bg-variant="dark" header-class="text-warning m-0 p-0" body-class="m-0 p-0" header="Sheriff Shifts:">             
                                     <b-table  
@@ -173,7 +173,7 @@
                         weekday: dayOffset, 
                         text:this.WeekDay[dayOffset],
                         name:this. weekDayNames[dayOffset], 
-                        variant:'danger',  
+                        variant:'white',  
                         style:'', 
                         shifts:[],
                         duties:[]
@@ -200,7 +200,7 @@
                 const filteredShifts = this.sheriffInfo.shifts.filter(shift=>{if(shift.startDate.substring(0,10)==schedule.date.substring(0,10))return true;});
                 const filteredDuties = this.sheriffInfo.dutiesDetail.filter(duty=>{if(duty.startTime && duty.startTime.substring(0,10)==schedule.date.substring(0,10))return true;});
                 if (filteredShifts.length == 0) {
-                    this.sheriffSchedules[scheduleIndex].variant = 'white';
+                    this.sheriffSchedules[scheduleIndex].variant = 'danger';
                 } else {
                     this.sheriffSchedules[scheduleIndex].shifts = filteredShifts 
                     this.sheriffSchedules[scheduleIndex].duties = filteredDuties

--- a/web/src/components/MyTeam/MyTeamMembers.vue
+++ b/web/src/components/MyTeam/MyTeamMembers.vue
@@ -88,17 +88,20 @@
                                 <b-tab v-if="editMode" title="Locations"> 
                                     <location-tab 
                                         v-on:change="getSheriffs()"
+                                        v-on:refresh="refreshProfile"
                                         v-on:closeMemberDetails="closeProfileWindow()"/>                                   
                                 </b-tab>
 
                                 <b-tab v-if="editMode" title="Leaves">
                                     <leave-tab 
                                         v-on:change="getSheriffs()"
+                                        v-on:refresh="refreshProfile"
                                         v-on:closeMemberDetails="closeProfileWindow()"/>                                    
                                 </b-tab>
 
                                 <b-tab v-if="editMode"  title="Training"> 
                                     <training-tab
+                                        v-on:refresh="refreshProfile"
                                         v-on:change="getSheriffs()"/>
                                 </b-tab>
 
@@ -368,6 +371,10 @@
                 this.allMyTeamData[index].image = image;
                 this.photokey++;
             }
+        }
+        public refreshProfile(userId){
+            this.closeProfileWindow()
+            this.openMemberDetails(userId)
         }      
 
         public openMemberDetails(userId){           

--- a/web/src/components/MyTeam/Tabs/LeaveTab.vue
+++ b/web/src/components/MyTeam/Tabs/LeaveTab.vue
@@ -51,7 +51,10 @@
                             <template v-slot:cell(endTime)="data" >
                                 <span v-if="!data.item.isFullDay">{{data.item.endDate | beautify-time }}</span> 
                             </template>
-                            <template v-slot:cell(editLeave)="data" >                                       
+                            <template v-slot:cell(editLeave)="data" >
+                                <b-button  size="sm" variant="transparent" style="margin:0; padding:0; width:1.2rem; float: left;">
+                                    <b-icon-chat-square-text-fill v-if="data.item.comment" v-b-tooltip.hover.left="data.item.comment"  class="mr-2" variant="info" font-scale="0.99"/>                                       
+                                </b-button>
                                 <b-button v-if="hasPermissionToEditUsers" class="my-0 py-0" size="sm" variant="transparent" @click="confirmDeleteLeave(data.item)"><b-icon icon="trash-fill" font-scale="1.25" variant="danger"/></b-button>
                                 <b-button v-if="hasPermissionToEditUsers" class="my-0 py-0" size="sm" variant="transparent" @click="editLeave(data)"><b-icon icon="pencil-square" font-scale="1.25" variant="primary"/></b-button>
                             </template>
@@ -99,9 +102,13 @@
                     <h2 class="mb-0 text-light">Conflicting Event</h2>                    
             </template>
             <h4>The following events conflict with this leave</h4>
-            <p v-for="event in overlappingList"
-                :key="event"> {{event}}
-            </p>
+                <ul>
+                    <li v-for="event in overlappingList"
+                        :key="event"
+                        class="mb-1"> {{event}}
+                    </li>
+                </ul>
+            <h4 class="mt-4 mb-0 text-danger">Do you want to override the conflicting event(s) listed above? </h4>
             <template v-slot:modal-footer>
                 <b-button variant="danger" @click="saveLeave(leaveToSave, create, true)">Confirm</b-button>
                 <b-button variant="primary" @click="cancelLeaveOverride()">Cancel</b-button>

--- a/web/src/components/MyTeam/Tabs/LeaveTab.vue
+++ b/web/src/components/MyTeam/Tabs/LeaveTab.vue
@@ -257,7 +257,11 @@
                         this.addToLeaveList(response.data);
                     else
                         this.modifyAssignedLeaveList(response.data);
-                    if (overrideConflicts)this.cancelLeaveOverride();
+                    if (overrideConflicts){
+                        this.cancelLeaveOverride();
+                        this.closeLeaveForm();
+                        this.$emit('refresh', this.userToEdit.id)
+                    }
                     this.closeLeaveForm();
                 }, err=>{                    
                     const errMsg = err.response.data.error;

--- a/web/src/components/MyTeam/Tabs/LocationTab.vue
+++ b/web/src/components/MyTeam/Tabs/LocationTab.vue
@@ -282,7 +282,11 @@
                         this.addToAssignedLocationList(response.data);
                     else
                         this.modifyAssignedLocationList(response.data);
-                    if (overrideConflicts)this.cancelAwayLocationOverride();
+                    if (overrideConflicts){
+                        this.cancelAwayLocationOverride();
+                        this.closeLocationForm();
+                        this.$emit('refresh', this.userToEdit.id)
+                    }
                     this.closeLocationForm();
                 }, err=>{   
                     // console.log(err.response.data);

--- a/web/src/components/MyTeam/Tabs/LocationTab.vue
+++ b/web/src/components/MyTeam/Tabs/LocationTab.vue
@@ -53,7 +53,10 @@
                             <template v-slot:cell(endTime)="data" >
                                 <span v-if="!data.item.isFullDay">{{data.item.endDate | beautify-time }}</span> 
                             </template>
-                            <template v-slot:cell(edit)="data" >                                      
+                            <template v-slot:cell(edit)="data" >
+                                <b-button  size="sm" variant="transparent" style="margin:0; padding:0; width:1.2rem; float: left;">
+                                    <b-icon-chat-square-text-fill v-if="data.item.comment" v-b-tooltip.hover.left="data.item.comment"  class="mr-2" variant="info" font-scale=".99"/>                                       
+                                </b-button>                                      
                                 <b-button v-if="hasPermissionToEditUsers" class="my-0 py-0" size="sm" variant="transparent" @click="confirmDeleteLocation(data.item)"><b-icon icon="trash-fill" font-scale="1.25" variant="danger"/></b-button>
                                 <b-button v-if="hasPermissionToEditUsers" class="my-0 py-0" size="sm" variant="transparent" @click="editLocation(data)"><b-icon icon="pencil-square" font-scale="1.25" variant="primary"/></b-button>
                             </template>
@@ -103,9 +106,13 @@
                     <h2 class="mb-0 text-light">Conflicting Event</h2>                    
             </template>
             <h4>The following events conflict with this location</h4>
-            <p v-for="event in overlappingList"
-                :key="event"> {{event}}
-            </p>
+                <ul>
+                    <li v-for="event in overlappingList"
+                        :key="event"
+                        class="mb-1"> {{event}}
+                    </li>
+                </ul>
+            <h4 class="mt-4 mb-0 text-danger">Do you want to override the conflicting event(s) listed above? </h4>
             <template v-slot:modal-footer>
                 <b-button variant="danger" @click="saveAwayLocation(locationToSave, create, true)">Confirm</b-button>
                 <b-button variant="primary" @click="cancelAwayLocationOverride()">Cancel</b-button>

--- a/web/src/components/MyTeam/Tabs/TrainingTab.vue
+++ b/web/src/components/MyTeam/Tabs/TrainingTab.vue
@@ -71,6 +71,9 @@
                                 <span>{{data.value | beautify-date}}</span> 
                             </template>
                             <template v-slot:cell(editTraining)="data" >
+                                <b-button  size="sm" variant="transparent" style="margin:0; padding:0; width:1.2rem; float: left;">
+                                    <b-icon-chat-square-text-fill v-if="data.item.note" v-b-tooltip.hover.left="data.item.note"  class="mr-2" variant="info" font-scale="0.99"/>                                       
+                                </b-button>
                                 <b-button :disabled="!hasPermissionToEditCompletedTraining && (data.item['_rowVariant']?true:false)" v-if="hasPermissionToEditUsers" class="my-0 py-0" size="sm" variant="transparent" @click="editTraining(data)"><b-icon icon="pencil-square" font-scale="1.25" variant="primary"/></b-button>                                       
                                 <b-button class="my-0 py-0" size="sm" variant="transparent" :disabled="!hasPermissionToRemoveCompletedTraining && (data.item['_rowVariant']?true:false)" v-if="hasPermissionToEditUsers" @click="confirmDeleteTraining(data.item)"><b-icon icon="trash-fill" font-scale="1.25" variant="danger"/></b-button>                                
                             </template>
@@ -116,9 +119,13 @@
                             <h2 class="mb-0 text-light">Conflicting Event</h2>                    
                     </template>
                     <h4>The following events conflict with this training</h4>
-                    <p v-for="event in overlappingList"
-                        :key="event"> {{event}}
-                    </p>
+                    <ul>
+                        <li v-for="event in overlappingList"
+                            :key="event"
+                            class="mb-1"> {{event}}
+                        </li>
+                    </ul>
+                    <h4 class="mt-4 mb-0 text-danger">Do you want to override the conflicting event(s) listed above? </h4>
                     <template v-slot:modal-footer>
                         <b-button variant="danger" @click="saveTraining(trainingToSave, create, true)">Confirm</b-button>
                         <b-button variant="primary" @click="cancelTrainingOverride()">Cancel</b-button>

--- a/web/src/components/MyTeam/Tabs/TrainingTab.vue
+++ b/web/src/components/MyTeam/Tabs/TrainingTab.vue
@@ -344,7 +344,11 @@
                             this.addToAssignedTrainingList(response.data);
                         else
                             this.modifyAssignedTrainingList(response.data);
-                        if (overrideConflicts)this.cancelTrainingOverride();
+                        if (overrideConflicts){
+                            this.cancelTrainingOverride();
+                            this.closeTrainingForm();
+                            this.$emit('refresh', this.userToEdit.id)
+                        }
                         this.closeTrainingForm();
                     }, err=>{
                         const errMsg = err.response.data.error;

--- a/web/src/components/ShiftSchedule/ManageSchedule.vue
+++ b/web/src/components/ShiftSchedule/ManageSchedule.vue
@@ -118,9 +118,10 @@
 
             this.headerDate();
 
-            const endDate = moment(this.shiftRangeInfo.endDate).endOf('day').format();
+            const endDate = moment.tz(this.shiftRangeInfo.endDate, this.location.timezone).endOf('day').utc().format();
+            const startDate = moment.tz(this.shiftRangeInfo.startDate, this.location.timezone).startOf('day').utc().format();
 
-            const url = 'api/shift/shiftavailability?locationId='+this.location.id+'&start='+this.shiftRangeInfo.startDate+'&end='+endDate;
+            const url = 'api/shift/shiftavailability?locationId='+this.location.id+'&start='+startDate+'&end='+endDate;
             this.$http.get(url)
                 .then(response => {
                     if(response.data){
@@ -219,7 +220,7 @@
                             
                             if (conflict.conflict == "Scheduled" && conflict.overtimeHours !=0) {
                                 
-                                const regularTimeEnd = moment(conflict.end).subtract(conflict.overtimeHours, 'h');
+                                const regularTimeEnd = moment(conflict.end).subtract(conflict.overtimeHours, 'h').tz(this.location.timezone);
                                 let duration = moment.duration(regularTimeEnd.diff(start));
                                 
                                 const regularShift = {
@@ -228,7 +229,7 @@
                                     dayOffset: Number(dateIndex), 
                                     date:this.headerDates[dateIndex], 
                                     startTime:Vue.filter('beautify-time')(conflict.start), 
-                                    endTime:Vue.filter('beautify-time')(regularTimeEnd.format("YYYY-MM-DDTHH:mm:ssZ")), 
+                                    endTime:Vue.filter('beautify-time')(regularTimeEnd.format()), 
                                     startInMinutes:moment.duration(start.diff(moment(conflict.start).startOf('day'))).asMinutes(),
                                     timeDuration:duration.asMinutes(), 
                                     type:this.getConflictsType(conflict), 
@@ -243,9 +244,9 @@
                                     location:conflict.conflict=='AwayLocation'?conflict.location.name:'',
                                     dayOffset: Number(dateIndex), 
                                     date:this.headerDates[dateIndex], 
-                                    startTime:Vue.filter('beautify-time')(regularTimeEnd.format("YYYY-MM-DDTHH:mm:ssZ")), 
+                                    startTime:Vue.filter('beautify-time')(regularTimeEnd.format()), 
                                     endTime:Vue.filter('beautify-time')(conflict.end), 
-                                    startInMinutes:moment.duration(regularTimeEnd.diff(moment(regularTimeEnd.format("YYYY-MM-DDTHH:mm:ssZ")).startOf('day'))).asMinutes(),
+                                    startInMinutes:moment.duration(regularTimeEnd.diff(moment(regularTimeEnd.format()).startOf('day'))).asMinutes(),
                                     timeDuration:duration.asMinutes(), 
                                     type:'overTimeShift', 
                                     fullday:false,


### PR DESCRIPTION
Change include:

- SS-647: Resolve the duty roster page issue with my-team column and duty-slots tooltips getting in the way of drag-drop 
- Make changes based on feedback: 
   - Resolve the issue on shifts with overtime, showing incorrect time range when in cranbrook 
   - Include startTime in the Get shiftAvailability call for loading the manage-schedule page 
   - SS-634: change wording for confirmation window
   - SS-625: add comment icon field for leave, location, training
   - Change the colors on the weekday icons for duty-roster: red/white
   - Add functionality such that if a user doesn't have access to the duty roster page, they'll be redirected to the request-access page
   - Add functionality to hide the "Work Section" switch if user doesn't have the "ViewDutyRoster" permission 